### PR TITLE
Normalize cover image URLs

### DIFF
--- a/script_iran_seda_final_STREAM_MERGE_v6_env.py
+++ b/script_iran_seda_final_STREAM_MERGE_v6_env.py
@@ -126,6 +126,8 @@ def parse_page(html: str, url: str):
     attid = extract_attid(soup)
     duration, episodes = parse_duration_and_episodes(soup)
     cover = get_og_image(soup) or find_first_image_src(soup)
+    if cover:
+        cover = abs_url(cover)
 
     q = parse_qs(urlparse(url).query)
     g = q.get("g", [None])[0]

--- a/tests/test_parse_page.py
+++ b/tests/test_parse_page.py
@@ -1,0 +1,23 @@
+import importlib.util
+import pathlib
+
+# Load the script module dynamically to avoid path issues
+script_path = pathlib.Path(__file__).resolve().parents[1] / 'script_iran_seda_final_STREAM_MERGE_v6_env.py'
+spec = importlib.util.spec_from_file_location('script_module', script_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+parse_page = mod.parse_page
+
+
+def test_cover_image_url_is_absolute():
+    html = '''<html><head>
+    <meta property="og:image" content="/images/cover.jpg?AttID=1234" />
+    </head><body>
+    <h1>Example Book</h1>
+    <div class="short-description">Short</div>
+    <div class="full-description">Full</div>
+    </body></html>'''
+    url = "https://book.iranseda.ir/Details?VALID=TRUE&g=5678"
+    parsed = parse_page(html, url)
+    assert parsed["Cover_Image_URL"] == "https://book.iranseda.ir/images/cover.jpg?AttID=1234"


### PR DESCRIPTION
## Summary
- Convert cover image URLs to absolute paths to prevent broken links
- Add unit test ensuring relative cover paths are normalized

## Testing
- `pytest -q`
- `python -m py_compile script_iran_seda_final_STREAM_MERGE_v6_env.py tests/test_parse_page.py`


------
https://chatgpt.com/codex/tasks/task_b_68a46fea80f883258314a7147b7327e3