### PR TITLE
Document optional INPUT_CSV environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
    - `run_name` (مثلاً `iranseda-1404-05-29`)
    - `source_url` (اختیاری؛ قالب با `{page}`)
    - `start_page` و `end_page` (اختیاری)
+   - متغیر محیطی اختیاری `INPUT_CSV` برای معرفی مسیر CSV ورودی دلخواه؛ در صورت تنظیم، به جای فایل پیش‌فرض `runs/<RUN_NAME>/raw/audiobooks_<RUN_NAME>.csv` استفاده می‌شود.
 4. پس از اجرا، فید در مسیر زیر در دسترس خواهد بود:
    ```
    https://<username>.github.io/<repo>/feeds/<RUN_NAME>/podcast.xml
    ```
 
 ## مسیر خروجی‌ها
+مسیرهای زیر با فرض متغیر محیطی `RUNS_DIR` برابر با `runs` هستند؛ با تغییر این متغیر می‌توانید محل ذخیره خروجی‌ها را عوض کنید.
 ```
 runs/<RUN_NAME>/raw/audiobooks_<RUN_NAME>.csv
 runs/<RUN_NAME>/merged/books_with_attid_<RUN_NAME>.csv


### PR DESCRIPTION
## Summary
- document INPUT_CSV environment variable for providing a custom input CSV
- note that RUNS_DIR can change base directory for output files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a47175becc83258622e7757434516d