### PR TITLE
Track and export failed audiobook rows

### DIFF
--- a/script_iran_seda_final_STREAM_MERGE_v6_env.py
+++ b/script_iran_seda_final_STREAM_MERGE_v6_env.py
@@ -164,6 +164,7 @@ def main():
 
     df_in = pd.read_csv(in_path, encoding="utf-8")
     merged_rows = []
+    error_rows = []
 
     for idx, row in df_in.iterrows():
         url = str(row["URL"]).strip()
@@ -180,7 +181,19 @@ def main():
             print(f"[{idx+1}/{len(df_in)}] ✓ {parsed.get('AudioBook_ID')}")
         except Exception as e:
             print(f"[{idx+1}/{len(df_in)}] ✗ {row.get('AudioBook_ID')}: {e}")
+            error_rows.append({
+                "AudioBook_ID": row.get("AudioBook_ID"),
+                "Error": str(e),
+            })
         time.sleep(random.uniform(0.1, 0.3))
+
+    if error_rows:
+        err_path = Path(ERR_CSV)
+        err_path.parent.mkdir(parents=True, exist_ok=True)
+        with err_path.open("w", newline="", encoding="utf-8-sig") as f:
+            w = csv.DictWriter(f, fieldnames=["AudioBook_ID", "Error"])
+            w.writeheader()
+            w.writerows(error_rows)
 
     out_path = Path(OUT_CSV)
     out_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- Collect failed rows with audiobook ID and error message
- Persist any errors to a dedicated CSV

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a47787a7a883259e4927568c5aa25e