### PR TITLE
Validate MP3 headers before generating podcast feed

### DIFF
--- a/tests/test_csv_to_podcast.py
+++ b/tests/test_csv_to_podcast.py
@@ -1,0 +1,36 @@
+import sys
+import pathlib
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from tools.csv_to_podcast import build_item
+
+
+def _mock_response(headers):
+    resp = MagicMock()
+    resp.headers = headers
+    resp.raise_for_status = lambda: None
+    return resp
+
+
+@patch("tools.csv_to_podcast.requests.head")
+def test_build_item_includes_content_length(mock_head):
+    headers = {
+        "Content-Type": "audio/mpeg",
+        "Accept-Ranges": "bytes",
+        "Content-Length": "321"
+    }
+    mock_head.return_value = _mock_response(headers)
+    row = {"Book_Title": "T", "FullBook_MP3_URL": "http://example.com/a.mp3"}
+    item = build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")
+    assert 'enclosure url="http://example.com/a.mp3" length="321" type="audio/mpeg"' in item
+
+
+@patch("tools.csv_to_podcast.requests.head")
+def test_build_item_raises_for_missing_headers(mock_head):
+    headers = {"Content-Type": "audio/mpeg", "Content-Length": "10"}  # missing Accept-Ranges
+    mock_head.return_value = _mock_response(headers)
+    row = {"Book_Title": "T", "FullBook_MP3_URL": "http://example.com/a.mp3"}
+    with pytest.raises(RuntimeError):
+        build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")


### PR DESCRIPTION
## Summary
- verify MP3 responses expose `Content-Type`, `Accept-Ranges`, and `Content-Length`
- record real file length in enclosure tag
- add tests for audio header validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a493be5b188325afa02ebc095de0d4