### PR TITLE
Expand RSS descriptions with book metadata

### DIFF
--- a/tests/test_csv_to_podcast.py
+++ b/tests/test_csv_to_podcast.py
@@ -46,3 +46,42 @@ def test_build_item_raises_for_missing_content_length(mock_head):
     row = {"Book_Title": "T", "FullBook_MP3_URL": "http://example.com/a.mp3"}
     with pytest.raises(RuntimeError):
         build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")
+
+
+@patch("tools.csv_to_podcast.requests.head")
+def test_build_item_contains_translated_fields(mock_head):
+    headers = {"Content-Type": "audio/mpeg", "Content-Length": "1"}
+    mock_head.return_value = _mock_response(headers)
+    row = {
+        "Book_Title": "عنوانی",
+        "Book_Description": "توضیحی",
+        "Book_Detail": "جزئیاتی",
+        "FullBook_MP3_URL": "http://example.com/a.mp3",
+    }
+    item = build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")
+    assert "عنوان کتاب: عنوانی" in item
+    assert "توضیحات کتاب: توضیحی" in item
+    assert "جزئیات/متن کامل معرفی: جزئیاتی" in item
+
+
+@patch("tools.csv_to_podcast.requests.head")
+def test_long_description_trims_optional_fields(mock_head):
+    headers = {"Content-Type": "audio/mpeg", "Content-Length": "1"}
+    mock_head.return_value = _mock_response(headers)
+    import tools.csv_to_podcast as mod
+    original_limit = mod.MAX_DESC_LENGTH
+    mod.MAX_DESC_LENGTH = 80
+    row = {
+        "Book_Title": "T",
+        "Book_Description": "D",
+        "Book_Detail": "DETAIL",
+        "Book_Language": "FA",
+        "Book_Country": "IR",
+        "FullBook_MP3_URL": "http://example.com/a.mp3",
+    }
+    try:
+        item = build_item(row, "Wed, 01 Jan 2024 00:00:00 +0000")
+    finally:
+        mod.MAX_DESC_LENGTH = original_limit
+    assert "زبان کتاب" not in item
+    assert "کشور (منشأ یا مخاطب)" not in item


### PR DESCRIPTION
## Summary
- Translate book metadata fields and enrich RSS item descriptions
- Drop optional metadata when description exceeds 4000 characters
- Cover new behavior with tests for translations and trimming logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4a0e739c083258bb52d4cec41c0d1