### PR TITLE
Handle invalid audio content types gracefully

### DIFF
--- a/tools/csv_to_podcast.py
+++ b/tools/csv_to_podcast.py
@@ -116,7 +116,15 @@ def build_item(row, pubdate):
                     break
         desc = _join(trimmed)
 
-    length = fetch_audio_length(audio)
+    try:
+        length = fetch_audio_length(audio)
+    except Exception as e:
+        # If we cannot determine the length or content type, skip this entry
+        # instead of terminating the whole feed generation process. This can
+        # happen when the remote server responds with HTML or another
+        # unexpected payload when a HEAD request is made.
+        print(f"Skipping {audio}: {e}")
+        return None
     guid_str = hashlib.sha1(audio.encode("utf-8")).hexdigest()
     parts = []
     parts.append("    <item>")


### PR DESCRIPTION
## Summary
- Skip feed items when audio URLs respond with unexpected content types or missing length
- Expand csv_to_podcast tests for missing content length and invalid content type cases

## Testing
- `pytest -q`
- `python tools/csv_to_podcast.py --csv /tmp/sample.csv --site https://example.com --out /tmp/out.xml`


------
https://chatgpt.com/codex/tasks/task_b_68a4a68853a08325adc9db4e49c9fa35